### PR TITLE
Add add_area and update_area MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,10 @@ Restart the Claude Desktop app to enable the integration.
 #### Modification Operations
 - `add_todo` - Create a new todo with full parameter support
 - `add_project` - Create a new project with tags and todos
+- `add_area` - Create a new area
 - `update_todo` - Update an existing todo
 - `update_project` - Update an existing project
+- `update_area` - Update an existing area
 - `show_item` - Show a specific item or list in Things
 - `search_items` - Search for items in Things
 
@@ -216,6 +218,18 @@ Restart the Claude Desktop app to enable the integration.
 - `tags` (optional) - New tags
 - `completed` (optional) - Mark as completed
 - `canceled` (optional) - Mark as canceled
+- `list_name` (optional) - Move project to a built-in list. One of: `Today`, `Anytime`, `Someday`, `Trash`. Projects cannot be moved to Inbox or Logbook (to move to Logbook, mark as completed instead).
+- `area_title` (optional) - Move the project to an area by name (must match an existing area exactly — look it up with `get_areas`)
+- `area_id` (optional) - Move the project to an area by ID (takes priority over `area_title` if both provided)
+
+### add_area
+- `title` - Title of the area
+- `tags` (optional) - Tags to apply to the area
+
+### update_area
+- `id` - ID of the area to update
+- `title` (optional) - New title
+- `tags` (optional) - New tags (pass an empty array to clear all tags)
 
 ### show_item
 - `id` - ID of item to show, or one of: inbox, today, upcoming, anytime, someday, logbook

--- a/src/things3_mcp/applescript_bridge.py
+++ b/src/things3_mcp/applescript_bridge.py
@@ -510,6 +510,104 @@ def update_todo(
     return result
 
 
+def add_area(
+    title: str,
+    tags: list[str] | None = None,
+) -> str | bool:
+    """Add an area to Things directly using AppleScript.
+
+    Args:
+    ----
+        title: Title of the area
+        tags: Tags to apply to the area
+
+    Returns:
+    -------
+        ID of the created area if successful, False otherwise
+    """
+    if not title or not title.strip():
+        logger.error("Title cannot be empty")
+        return False
+
+    if not ensure_things_ready():
+        logger.error("Things app is not ready for operations")
+        return False
+
+    script_parts = ['tell application "Things3"', "try"]
+    script_parts.append(f"set newArea to make new area with properties {{name:{escape_applescript_string(title)}}}")
+
+    if tags:
+        tag_string = ", ".join(tags)
+        escaped_tag_string = escape_applescript_string(tag_string)
+        script_parts.append(f"set tag names of newArea to {escaped_tag_string}")
+
+    script_parts.append("return id of newArea")
+    script_parts.append("on error errMsg")
+    script_parts.append('  log "Error creating area: " & errMsg')
+    script_parts.append("  return false")
+    script_parts.append("end try")
+    script_parts.append("end tell")
+
+    script = "\n".join(script_parts)
+    logger.debug(f"Executing AppleScript: {script}")
+
+    result = run_applescript(script, timeout=8)
+    if result and result != "false" and "script error" not in result and not result.startswith("/var/folders/") and not result.startswith("Error:"):
+        logger.info(f"Successfully created area via AppleScript with ID: {result}")
+        return result
+    logger.error(f"Failed to create area: {result}")
+    return False
+
+
+def update_area(
+    id: str,
+    title: str | None = None,
+    tags: list[str] | None = None,
+) -> str:
+    """Update an existing area in Things.
+
+    Args:
+    ----
+        id: ID of the area to update
+        title: New title for the area
+        tags: New tags (replaces existing tags; pass an empty list to clear)
+
+    Returns:
+    -------
+        "true" if successful, error message if failed
+    """
+    if not ensure_things_ready():
+        logger.error("Things app is not ready for operations")
+        return "Error: Things app is not ready"
+
+    script_parts = ['tell application "Things3"']
+    script_parts.append("try")
+    script_parts.append(f'    set theArea to first area whose id is "{id}"')
+
+    if title:
+        script_parts.append(f"    set name of theArea to {escape_applescript_string(title)}")
+
+    if tags is not None:
+        if tags:
+            tag_string = ", ".join(tags)
+            escaped_tag_string = escape_applescript_string(tag_string)
+            script_parts.append(f"    set tag names of theArea to {escaped_tag_string}")
+        else:
+            script_parts.append('    set tag names of theArea to ""')
+
+    script_parts.append("    return true")
+    script_parts.append("on error errMsg")
+    script_parts.append('    return "Error: " & errMsg')
+    script_parts.append("end try")
+    script_parts.append("end tell")
+
+    script = "\n".join(script_parts)
+    logger.debug(f"Generated AppleScript:\n{script}")
+    result = run_applescript(script)
+    logger.debug(f"AppleScript result: {result!r}")
+    return result
+
+
 def add_project(
     title: str,
     notes: str | None = None,

--- a/src/things3_mcp/fast_server.py
+++ b/src/things3_mcp/fast_server.py
@@ -8,9 +8,11 @@ import things
 from mcp.server.fastmcp import FastMCP
 
 from .applescript_bridge import (
+    add_area,
     add_project,
     add_todo,
     ensure_things_ready,
+    update_area,
     update_project,
     update_todo,
 )
@@ -898,6 +900,95 @@ def update_existing_project(
         logger.error(f"Error updating project: {e!s}")
         logger.error(f"Full traceback: {traceback.format_exc()}")
         return f"⚠️ Error updating project: {e!s}"
+
+
+@mcp.tool(name="add_area")
+def add_new_area(
+    title: str,
+    tags: list[str] | str | None = None,
+) -> str:
+    """Create a new area in Things.
+
+    Args:
+    ----
+        title: Title of the area
+        tags: Tags to apply to the area. IMPORTANT: Always pass as an array of
+            strings (e.g., ["tag1", "tag2"]) NOT as a comma-separated string.
+            Passing as a string will treat each character as a separate tag.
+    """
+    try:
+        params = preprocess_array_params(tags=tags)
+        tags = params["tags"]
+
+        if isinstance(title, str):
+            title = title.replace("+", " ").replace("%20", " ")
+
+        logger.info(f"Creating area using AppleScript: {title}")
+
+        try:
+            area_id = add_area(title=title, tags=tags)
+        except Exception as bridge_error:
+            logger.error(f"AppleScript bridge error: {bridge_error}")
+            return f"⚠️ AppleScript bridge error: {bridge_error}"
+
+        if not area_id:
+            return "Error: Failed to create area using AppleScript"
+
+        return f"✅ Successfully created area: {title} (ID: {area_id})"
+
+    except Exception as e:
+        logger.error(f"Error creating area: {e!s}")
+        logger.error(f"Full traceback: {traceback.format_exc()}")
+        return f"⚠️ Error creating area: {e!s}"
+
+
+@mcp.tool(name="update_area")
+def update_existing_area(
+    id: str,
+    title: str | None = None,
+    tags: list[str] | str | None = None,
+) -> str:
+    """Update an existing area in Things.
+
+    Args:
+    ----
+        id: ID of the area to update
+        title: New title for the area
+        tags: New tags. IMPORTANT: Always pass as an array of strings
+            (e.g., ["tag1", "tag2"]) NOT as a comma-separated string. Pass an
+            empty array to clear all tags. Passing as a string will treat each
+            character as a separate tag.
+    """
+    try:
+        params = preprocess_array_params(tags=tags)
+        tags = params["tags"]
+
+        if isinstance(title, str):
+            title = title.replace("+", " ").replace("%20", " ")
+
+        logger.info(f"Updating area using AppleScript: {id}")
+
+        try:
+            success = update_area(id=id, title=title, tags=tags)
+            logger.debug(f"AppleScript bridge returned: {success!r} (type: {type(success)})")
+
+            if "true" in str(success).lower():
+                return f"✅ Successfully updated area with ID: {id}"
+            if success.startswith("Error:"):
+                logger.error(f"AppleScript error: {success}")
+                return success
+            logger.error(f"AppleScript update failed with result: {success!r}")
+            return f"Error: Failed to update area using AppleScript. Result: {success}"
+
+        except Exception as bridge_error:
+            logger.error(f"AppleScript bridge error: {bridge_error}")
+            logger.error(f"Full bridge error traceback: {traceback.format_exc()}")
+            return f"⚠️ AppleScript bridge error: {bridge_error}"
+
+    except Exception as e:
+        logger.error(f"Error updating area: {e!s}")
+        logger.error(f"Full traceback: {traceback.format_exc()}")
+        return f"⚠️ Error updating area: {e!s}"
 
 
 @mcp.tool(name="show_item")

--- a/tests/test_area_operations.py
+++ b/tests/test_area_operations.py
@@ -1,0 +1,116 @@
+"""Test suite for Things area operations.
+
+This module tests the add_area and update_area functionality.
+"""
+
+import os
+import sys
+
+# Add the src directory to the path so we can import our modules
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+import things  # noqa: E402
+
+from things3_mcp.applescript_bridge import (  # noqa: E402
+    add_area,
+    update_area,
+)
+
+from .conftest import (  # noqa: E402
+    generate_random_string,
+)
+
+# ============================================================================
+# ADD_AREA TESTS
+# ============================================================================
+
+
+def test_add_area_basic(test_namespace, cleanup_tracker):
+    """Create a bare area and verify it appears in Things."""
+    title = f"{test_namespace}-Area-{generate_random_string(5)}"
+    area_id = add_area(title=title)
+    assert area_id, f"add_area returned falsy value: {area_id!r}"
+    cleanup_tracker.add_area(area_id)
+
+    area = things.areas(uuid=area_id)
+    assert area, f"Area not found via things.areas() with uuid={area_id}"
+    assert area["title"] == title
+
+
+def test_add_area_with_tags(test_namespace, cleanup_tracker):
+    """Create an area with tags and verify the tags are applied."""
+    title = f"{test_namespace}-Area-Tagged-{generate_random_string(5)}"
+    tag_a = f"{test_namespace}-tag-{generate_random_string(4)}"
+    tag_b = f"{test_namespace}-tag-{generate_random_string(4)}"
+
+    area_id = add_area(title=title, tags=[tag_a, tag_b])
+    assert area_id, "add_area with tags returned falsy"
+    cleanup_tracker.add_area(area_id)
+    cleanup_tracker.add_tag(tag_a)
+    cleanup_tracker.add_tag(tag_b)
+
+    area = things.areas(uuid=area_id, include_items=False)
+    assert area, "Tagged area not found"
+    applied_tags = {t["title"] if isinstance(t, dict) else str(t) for t in area.get("tags", [])}
+    assert tag_a in applied_tags, f"Tag {tag_a} missing from {applied_tags}"
+    assert tag_b in applied_tags, f"Tag {tag_b} missing from {applied_tags}"
+
+
+def test_add_area_empty_title_returns_false():
+    """Empty/whitespace title is rejected before AppleScript is invoked."""
+    assert add_area(title="") is False
+    assert add_area(title="   ") is False
+
+
+# ============================================================================
+# UPDATE_AREA TESTS
+# ============================================================================
+
+
+def test_update_area_rename(test_namespace, cleanup_tracker):
+    """Rename an existing area via update_area."""
+    original = f"{test_namespace}-Area-Original-{generate_random_string(5)}"
+    renamed = f"{test_namespace}-Area-Renamed-{generate_random_string(5)}"
+
+    area_id = add_area(title=original)
+    assert area_id, "Setup: failed to create area"
+    cleanup_tracker.add_area(area_id)
+
+    result = update_area(id=area_id, title=renamed)
+    assert "true" in str(result).lower(), f"update_area did not succeed: {result!r}"
+
+    area = things.areas(uuid=area_id)
+    assert area["title"] == renamed, f"Title not updated: got {area['title']!r}"
+
+
+def test_update_area_replace_tags(test_namespace, cleanup_tracker):
+    """Replace area tags via update_area, then clear them with an empty list."""
+    title = f"{test_namespace}-Area-Retag-{generate_random_string(5)}"
+    initial_tag = f"{test_namespace}-tag-{generate_random_string(4)}"
+    replacement_tag = f"{test_namespace}-tag-{generate_random_string(4)}"
+
+    area_id = add_area(title=title, tags=[initial_tag])
+    assert area_id, "Setup: failed to create area with initial tag"
+    cleanup_tracker.add_area(area_id)
+    cleanup_tracker.add_tag(initial_tag)
+    cleanup_tracker.add_tag(replacement_tag)
+
+    # Replace the tags
+    result = update_area(id=area_id, tags=[replacement_tag])
+    assert "true" in str(result).lower(), f"update_area replace failed: {result!r}"
+    area = things.areas(uuid=area_id)
+    applied = {t["title"] if isinstance(t, dict) else str(t) for t in area.get("tags", [])}
+    assert replacement_tag in applied, f"Replacement tag missing: {applied}"
+    assert initial_tag not in applied, f"Initial tag should have been replaced: {applied}"
+
+    # Clear all tags
+    result = update_area(id=area_id, tags=[])
+    assert "true" in str(result).lower(), f"update_area clear failed: {result!r}"
+    area = things.areas(uuid=area_id)
+    assert not area.get("tags"), f"Tags should be empty, got: {area.get('tags')}"
+
+
+def test_update_area_invalid_id_returns_error():
+    """Calling update_area with a non-existent id returns an Error: string."""
+    result = update_area(id="this-id-does-not-exist-xyz-12345", title="ignored")
+    assert "Error" in str(result), f"Expected error string, got: {result!r}"


### PR DESCRIPTION
## Summary

Adds two new modification operations to round out area parity with projects:

- **`add_area(title, tags=None)`** — create a new area, optionally with tags.
- **`update_area(id, title=None, tags=None)`** — rename an area and/or replace its tags. Passing `tags=[]` clears all tags.

Also documents the existing `area_id`, `area_title`, and `list_name` parameters on `update_project`, which are already implemented in the AppleScript bridge and MCP wrapper but missing from the `update_project` section of the README.

### Why

`get_areas` exists but there was no way to *create* or *modify* areas via the MCP server — clients have to drop down to raw AppleScript or click around in the app. With this PR, an AI client can set up a fresh Things workspace end-to-end through the MCP.

### Tested

- New file `tests/test_area_operations.py` covers:
  - `add_area` happy path
  - `add_area` with tags
  - `add_area` empty-title rejection
  - `update_area` rename
  - `update_area` tag replace + clear
  - `update_area` invalid-id error path
- End-to-end smoke test against a live Things 3 install via the `@mcp.tool` wrappers (`add_new_area` → `update_existing_area` → cleanup).
- Full pre-commit gauntlet matching `lint.yml`: `py_compile`, `ruff check .`, `ruff format --check .`, `mypy src/`, `bandit -r src/` — all pass.
- Full pytest run: all 6 new tests pass. The 5 unrelated failures in `tests/test_list_operations.py` are pre-existing on `main` (format-string assertions tripping on Things 3.20's stock onboarding todos) and unchanged by this PR.

### Notes

- Areas in Things only expose `name` and `tags` via AppleScript (no notes, no scheduling, no deadlines), so the surface is intentionally smaller than `add_project` / `update_project`.
- Did not add `delete_area` for parity with the existing API (no `delete_project` either) — happy to add it as a follow-up if you'd like.

## Test plan

- [x] `pytest tests/test_area_operations.py` passes
- [x] Full suite has no new regressions vs `main`
- [x] `ruff check .` clean
- [x] `ruff format --check .` clean
- [x] `mypy src/` clean
- [x] `bandit -r src/` clean
- [x] Manual end-to-end: create area, rename, retag, clear tags, delete via AppleScript